### PR TITLE
Fix double reshape

### DIFF
--- a/ALabel.tscn
+++ b/ALabel.tscn
@@ -15,5 +15,9 @@ margin_top = 94.4549
 margin_right = 252.983
 margin_bottom = 117.455
 custom_fonts/font = SubResource( 1 )
-text = "سلام"
+text = "ﻡﻼﺳ"
 script = ExtResource( 3 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+arabic_input = "سلام"

--- a/addons/arabic-text/ALabel.gd
+++ b/addons/arabic-text/ALabel.gd
@@ -1,3 +1,4 @@
+tool
 extends Label
 
 var reshaper = preload('res://addons/arabic-text/reshaper/arabic_reshaper.gd').new()
@@ -5,14 +6,21 @@ var bidi = preload("res://addons/arabic-text/bidi/algorithm.gd").new()
 
 var prev_text = ''
 
+# Use this for input rather than `text`
+export(String, MULTILINE) var arabic_input = '' setget _set_arabic_input
+
+func _set_arabic_input(s):
+	arabic_input = s
+	_on_ALabel_draw()
+
 func display():
-	text = bidi.get_display(reshaper.reshape(text))
+	text = bidi.get_display(reshaper.reshape(arabic_input))
 
 func _ready():
 	display()
 	connect("draw", self, "_on_ALabel_draw")
 
 func _on_ALabel_draw():
-	if text != prev_text:
+	if arabic_input != prev_text:
 		display()
-		prev_text = text
+		prev_text = arabic_input


### PR DESCRIPTION
Sometimes (on resize) the text would get reshaped twice and breake
This commit adds an `arabic_input` property so the `text` always
holds the reshaped one.