### PR TITLE
Correctly ported some methods to their gdscript equivalents

### DIFF
--- a/addons/arabic-text/bidi/algorithm.gd
+++ b/addons/arabic-text/bidi/algorithm.gd
@@ -1,3 +1,4 @@
+tool
 # This file is part of python-bidi
 #
 # python-bidi is free software: you can redistribute it and/or modify
@@ -171,8 +172,9 @@ func explicit_embed_and_overrides(storage, debug=False):
 						embedding_level != EXPLICIT_LEVEL_LIMIT - 1:
 					almost_overflow_counter -= 1
 				elif levels:
-					embedding_level = levels.pop()[0]
-					directional_override = levels.pop()[1]
+					var tmp = levels.pop_back()
+					embedding_level = tmp[0]
+					directional_override = tmp[1]
 
 			# X8
 			elif bidi_type == 'B':
@@ -307,7 +309,7 @@ func resolve_weak_types(storage, debug=False):
 			prev_type = chars[idx-1]['type']
 			var next_type = chars[idx+1]['type']
 
-			if bidi_type == 'ES' and (prev_type == next_type == 'EN'):
+			if bidi_type == 'ES' and prev_type == next_type and prev_type == 'EN':
 				chars[idx]['type'] = 'EN'
 
 			if bidi_type == 'CS' and prev_type == next_type and \

--- a/addons/arabic-text/reshaper/arabic_reshaper.gd
+++ b/addons/arabic-text/reshaper/arabic_reshaper.gd
@@ -124,10 +124,10 @@ func reshape(text):
 
 		# Remove ZWJ if it's the second to last item as it won't be useful
 		if support_zwj and len(output) > 1 and output[-2][LETTER] == ZWJ:
-			output.pop(len(output) - 2)
+			output.remove(len(output) - 2)
 
 	if support_zwj and output and output[-1][LETTER] == ZWJ:
-		output.pop()
+		output.pop_back()
 
 	# Clean text from Harakat to be able to find ligatures
 	text = HARAKAT_RE.sub(text, '')
@@ -171,7 +171,8 @@ func reshape(text):
 
 	var result = []
 	if not delete_harakat and -1 in positions_harakat:
-		result.extend(positions_harakat[-1])
+		#result.extend(positions_harakat[-1])
+		result +=positions_harakat[-1]
 	for o in output:
 		var i = output.find(o)
 		if o[LETTER]:
@@ -182,7 +183,8 @@ func reshape(text):
 
 		if not delete_harakat:
 			if i in positions_harakat:
-				result.extend(positions_harakat[i])
+				#result.extend(positions_harakat[i])
+				result += positions_harakat[i]
 	
 	var str_result = ''
 	for s in result:


### PR DESCRIPTION
More complex text (e.g: https://r12a.github.io/scripts/tutorial/summaries/arabic )
was failing due to part of the code using methods present in python but not in gdscript

Notably:
| Python | GDScript |
|--------|----------|
| my_list.extend(other_list) | my_array += other_array
| List.pop() | Array.pop_back() |
| my_list.pop(idx) | my_list[idx]; my_list.remove(idx) |
| a,b = some_array.pop() | var tmp = some_array.pop(); a = tmp[0]; b= tmp[1] |
| a == b == "some string" | a == b and b == "some string" |

Known issues:
- The latin text was reversed in the output. I could paste the reversed output into arabic_input to get it to display correctly but it's cumbersome
- Autowrap doesn't work corectly but I'm pretty sure it didn't before. I don't know if there is a way to fix that in gdscript without proper RTL support.